### PR TITLE
Add travis ci integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,44 @@
+language: cpp
+
+os:
+  - linux
+  - osx
+
+osx_image: xcode7
+
+compiler:
+  - clang
+  - gcc
+
+notifications:
+ email:
+   on_success: change
+   on_failure: always
+
+install:
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+    wget --no-check-certificate https://cmake.org/files/v3.5/cmake-3.5.0-Linux-x86_64.tar.gz
+      && tar -xzf cmake-3.5.0-Linux-x86_64.tar.gz
+      && sudo cp -fR cmake-3.5.0-Linux-x86_64/* /usr
+      && sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+      && sudo apt-get update -qq
+      && sudo apt-get install -qq -y --force-yes gcc-5 g++-5
+      && sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-5 90
+      && sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-5 90;
+    fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+    brew update
+      && ((brew list -1 | grep -q "^$cmake\$") || brew install cmake)
+      && (brew outdated cmake || brew upgrade cmake)
+      && cmake --version;
+    fi
+
+before_script:
+  - mkdir build
+  - cd build
+  - cmake ../tests/
+
+script:
+  - make
+  - make tests
+  - ./tests

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # zenbench - a minimal micro benchmark library
    * Header - only
    * Solely depends on a C++ 11 capable compiler
-   
+
+[![Build Status](https://travis-ci.org/NewProggie/zenbench.svg?branch=master)](https://travis-ci.org/NewProggie/zenbench) [![License](https://img.shields.io/badge/license-MIT-blue.svg)](http://opensource.org/licenses/MIT)
+
 ### basic usage
 All benchmarks must be created and registered with the `BENCHMARK(name)` or the `BENCHMARK_F(fixture,name)` macro:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
    * Header - only
    * Solely depends on a C++ 11 capable compiler
 
-[![Build Status](https://travis-ci.org/NewProggie/zenbench.svg?branch=master)](https://travis-ci.org/NewProggie/zenbench) [![License](https://img.shields.io/badge/license-MIT-blue.svg)](http://opensource.org/licenses/MIT)
+[![Build Status](https://travis-ci.org/nafest/zenbench.svg?branch=master)](https://travis-ci.org/nafest/zenbench) [![License](https://img.shields.io/badge/license-MIT-blue.svg)](http://opensource.org/licenses/MIT)
 
 ### basic usage
 All benchmarks must be created and registered with the `BENCHMARK(name)` or the `BENCHMARK_F(fixture,name)` macro:

--- a/include/zenbench.h
+++ b/include/zenbench.h
@@ -162,8 +162,8 @@ public:
             benchmark->RunBenchmark(ctxt);
             benchmark->TearDown();
             std::ostringstream ost;
-            auto timePerIteration = ctxt.TimePerIteration(overheadCtxt.TimePerIteration());
-            timePerIteration = std::max(timePerIteration,0ll);
+            int64_t timePerIteration = ctxt.TimePerIteration(overheadCtxt.TimePerIteration());
+            timePerIteration = std::max<int64_t>(timePerIteration,0ll);
             ost << timePerIteration;
             auto nanoStr = ost.str();
             std::cout << std::left << std::setw(maxLength) << benchmark->Name() << "  ";

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,9 +39,10 @@ set_target_properties (libgtest_main PROPERTIES
 set (GTEST_INCLUDES "${source_dir}/googletest/include")
 
 project (ZenBenchTests)
+find_package(Threads REQUIRED)
 
 set (CMAKE_CXX_STANDARD 11)
 
 include_directories(../include ${GTEST_INCLUDES})
 add_executable (tests Context_tests.cpp)
-target_link_libraries (tests libgtest libgtest_main)
+target_link_libraries (tests libgtest libgtest_main ${CMAKE_THREAD_LIBS_INIT})


### PR DESCRIPTION
I've added a travis ci script which builds this project under Linux as well as OS X with GCC 5.0 and Clang 3.4.
![Travis CI](http://i.imgur.com/fAPWwjM.png)

In order to make travis work you should open up an account over at https://travis-ci.org/ (using your Github account for convenience).
